### PR TITLE
修正；PHP 5.6不截断0x00，导致info[ver]对比失败引发缓存重建，而导致缓存无法存入问题（附测试脚本）

### DIFF
--- a/demo/test.php
+++ b/demo/test.php
@@ -1,0 +1,57 @@
+<?php
+
+require(dirname(__FILE__). '/../secache.php');
+
+$cacheFileName = 'R:\cachedatadefault';
+$insertCount = 1000;
+
+$cache = new secache();
+$cache->workat($cacheFileName);
+
+function microtime_float(){
+    list($usec, $sec) = explode(" ", microtime());
+    return ((float)$usec + (float)$sec);
+}
+
+$begin_time = microtime_float();
+
+for($i=0;$i<$insertCount;$i++){
+
+    $key = md5($i); //You must *HASH* it by your self
+    $value = 'No. '.$i.' is ok'; // must be a *STRING*
+
+    $cache->store($key,$value);
+}
+
+echo '================='. PHP_EOL;
+echo 'Insert '. $insertCount. ' Count Cost: ' .( microtime_float() - $begin_time) .' ms'. PHP_EOL;
+echo '================='. PHP_EOL;
+
+echo 'Test read'. PHP_EOL;
+echo '================='. PHP_EOL;
+testRead($cache, $insertCount);
+
+echo '================='. PHP_EOL;
+echo 'Test read again'. PHP_EOL;
+echo '================='. PHP_EOL;
+
+unset($cache);
+$cache = new secache();
+$cache->workat($cacheFileName);
+testRead($cache, $insertCount);
+
+function testRead($cache, $insertCount){
+
+    for($i=0;$i<$insertCount;$i+=200){
+
+        $key = md5($i); //You must *HASH* it by your self
+	
+        if($cache->fetch($key,$value)){
+            echo $i. '[KEY='. $key.'] DATA: '.$value. PHP_EOL;
+        }else{
+            echo $i. '[KEY='. $key.'] DATA GET FAILED '. PHP_EOL;
+	    	exit();
+        }
+    }
+
+}

--- a/secache.php
+++ b/secache.php
@@ -5,7 +5,7 @@
  * pure-php coded key-value database engine created by shopex.
  * @version $Id$
  *
- * http://code.google.com/p/secache/
+ * @link https://github.com/shopex/secache
  */
 if(!defined('SECACHE_SIZE')){
     define('SECACHE_SIZE','15M');
@@ -13,6 +13,7 @@ if(!defined('SECACHE_SIZE')){
 class secache{
 
     var $idx_node_size = 40;
+	var $idx_node_base = 0;
     var $data_base_pos = 262588; //40+20+24*16+16*16*16*16*4;
     var $schema_item_size = 24;
     var $header_padding = 20; //保留空间 放置php标记防止下载
@@ -64,6 +65,7 @@ class secache{
             $this->_rs = fopen($this->_file,'rb+') or $this->trigger_error('Can\'t open the cachefile: '.realpath($this->_file),E_USER_ERROR);
             $this->_seek($this->header_padding);
             $info = unpack('V1max_size/a*ver',fread($this->_rs,$this->info_size));
+			$info['ver'] = trim($info['ver']);
             if($info['ver']!=$this->ver){
                 $this->_format(true);
             }else{


### PR DESCRIPTION
这个问题是更换了运行环境到php 5.6之后才发现的。

虽然说现在大多数时候已经用内存型缓存了，不过这个文件型缓存有时候还可以应急一下。

如果有需要的话，可以将带缓存时间的ttl分支也推送到你们这里。
